### PR TITLE
Implement 'PATH_COLOR_ALPHA' command

### DIFF
--- a/media/vector-icon.js
+++ b/media/vector-icon.js
@@ -134,6 +134,11 @@ class VectorIcon {
       return;
     }
 
+    if (cmd[0] === 'PATH_COLOR_ALPHA') {
+      this.currentPath_.style['opacity'] = cmd[1] / 255;
+      return;
+    }
+
     if (cmd[0] === 'PATH_COLOR_ARGB') {
       const color =
         'rgba(' + [cmd[2], cmd[3], cmd[4], cmd[1]]


### PR DESCRIPTION
ToT currently renders some icons with `PATH_COLOR_ALPHA` as shown on the left. After applying this PR, they are rendered as shown on the right.

[notification_battery_fluctuating.icon](https://source.chromium.org/chromium/chromium/src/+/main:ash/resources/vector_icons/notification_battery_fluctuating.icon)
![image](https://github.com/adolfdaniel/vscode-chromium-vector-icons/assets/63662403/70efb3dc-6155-403d-b354-3ed3f70d0e5e) ![image](https://github.com/adolfdaniel/vscode-chromium-vector-icons/assets/63662403/bd7428e3-ea37-450b-a4a0-3cf8e6326608)

[notification_bluetooth_battery_warning.icon](https://source.chromium.org/chromium/chromium/src/+/main:ash/resources/vector_icons/notification_bluetooth_battery_warning.icon)
![image](https://github.com/adolfdaniel/vscode-chromium-vector-icons/assets/63662403/562de68d-5580-41a9-a793-4aa1725a14c7) ![image](https://github.com/adolfdaniel/vscode-chromium-vector-icons/assets/63662403/05120ef1-83c3-432a-b372-394512357c8e)
