### PR TITLE
Don't fill the path when the command is 'STROKE'

### DIFF
--- a/media/vector-icon.js
+++ b/media/vector-icon.js
@@ -150,6 +150,7 @@ class VectorIcon {
 
     if (cmd[0] === 'STROKE') {
       this.currentPath_.setAttribute('stroke-width', cmd[1] + 'px');
+      this.currentPath_.style['fill'] = 'transparent';
       return;
     }
 


### PR DESCRIPTION
Chromium fills the path of a vector icon by default, and when 'STROKE' command is given it only paints the border of a path. But this extension has the problem of painting the path when 'STROKE' command is given. This patch fixes this.

After applying this PR, icons with `STROKE` are rendered as shown on the right.

ISSUE=#1

```
CANVAS_DIMENSIONS, 24,

NEW_PATH,
STROKE, 3,
CIRCLE, 12, 12, 9.5,

NEW_PATH,
CIRCLE, 12, 12, 6
```

![image](https://github.com/adolfdaniel/vscode-chromium-vector-icons/assets/63662403/2fd63303-94b6-4d13-8cb4-26c78e85fee9) ![image](https://github.com/adolfdaniel/vscode-chromium-vector-icons/assets/63662403/eedded77-c7d7-4fd5-9a01-c8953b855467)
